### PR TITLE
Adding coveralls for a published view of code coverage pushed out form b...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 install:
   - pip install -r requirements.txt
+  - pip install coveralls
 before_script:
   - "export TEAMTEMP_SECRET_KEY=test_key"
   - "export DATABASE_URL=sqlite:///:memory"
 script:
   coverage run manage.py test
+after_success:
+  coveralls

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ coverage report -m
 Build Health
 -----------
 [![Build Status](https://travis-ci.org/teamtemp/teamtemp.svg?branch=master)](https://travis-ci.org/teamtemp/teamtemp)
+[![Coverage Status](https://coveralls.io/repos/teamtemp/teamtemp/badge.png)](https://coveralls.io/r/teamtemp/teamtemp)


### PR DESCRIPTION
Have configured coveralls to generate code coverage reports based on team temp organisation repository.

To do this, I needed to make my personal membership of the github organisation public so coveralls can see the repository.  Solution sourced from https://github.com/lemurheavy/coveralls-public/issues/199.

Now on successful build, code coverage report will be run in coveralls and badge in read me file will be available for link and quick visual indication of metric.

I am yet to configure any warnings around code coverage regression.

https://coveralls.io/r/teamtemp/teamtemp
